### PR TITLE
install less command in container based ubuntu #95

### DIFF
--- a/django/Dockerfile
+++ b/django/Dockerfile
@@ -9,7 +9,7 @@ ENV PYTHONDONTWRITEBYTECODE 1
 # Pythonが標準入出力をバッファリングすることを防ぐ
 ENV PYTHONUNBUFFERED 1
 
-RUN apt-get update && apt-get install -y --no-install-recommends netcat
+RUN apt-get update && apt-get install -y --no-install-recommends netcat less
 
 # install dependencies
 RUN pip install --upgrade pip

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,6 +2,8 @@ FROM node:14.17.4
 
 WORKDIR /app
 
+RUN apt-get update && apt-get install -y --no-install-recommends less
+
 COPY ./package.json .
 COPY ./package-lock.json .
 


### PR DESCRIPTION
# 概要
<!-- 何がどう変わる変更なのか -->
ubuntuベースのコンテナにはlessコマンドがなかったためインストールした

# 対応するIssue
<!-- Issueへのリンクを貼る（例：#123） -->
close #95

# 修正内容の確認方法
<!-- 修正がどう反映されるかを確認する手順（あれば） -->
1. buildしてup
2. django, frontendコンテナに入ってlessコマンドを使用
3. 一応nginx, postgresもlessコマンドが使えるか確認(ashで入ることに注意)

# レビューのポイント
<!-- レビュワーに特に見てほしいポイント（あれば） -->


# 備考
<!-- 他PR, issueとの兼ね合いやその他考慮が必要な事項（あれば） -->
@kathmandu777 の独断でlessコマンドを導入しましたが、viewやmoreなどがよければいってください。
またほかにlogを見るのにいいコマンドがあれば教えてほしいです。

<!-- 必ずしも全て埋めなくてよいが、必要な情報をわかりやすく書く。 -->
