### PR TITLE
feat: ignore flake8 error of F401,F403 on __init__.py #222

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,7 @@
 exclude = django/*/migrations/*
 max-line-length = 119
 extend-ignore = W504
+per-file-ignores = __init__.py:F401,F403
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
# 概要
<!-- 何がどう変わる変更なのか -->
__init__.pyにlinterをかけた際にflake8がF401,F403を無視するようになる

# 対応するIssue
<!-- Issueへのリンクを貼る（例：#123） -->
close #222 

# 修正内容の確認方法
<!-- 修正がどう反映されるかを確認する手順（あれば） -->


# レビューのポイント
<!-- レビュワーに特に見てほしいポイント（あれば） -->


# 備考
<!-- 他PR, issueとの兼ね合いやその他考慮が必要な事項（あれば） -->


<!-- 必ずしも全て埋めなくてよいが、必要な情報をわかりやすく書く。 -->
