### PR TITLE
fix: downgrade protobuf

### DIFF
--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -23,7 +23,7 @@ idna==3.2
 msgpack==1.0.2
 packaging==21.0
 proto-plus==1.19.4
-protobuf==3.18.1
+protobuf==3.17.3
 psycopg2-binary==2.9.1
 pyasn1==0.4.8
 pyasn1-modules==0.2.8


### PR DESCRIPTION
# Overview <!-- What is the change -->
protobufのバージョンを下げた
google-api-coreのdependenciesの関係で

```bash
#11 15.31 INFO: pip is looking at multiple versions of asgiref to determine which version is compatible with other requirements. This could take a while.
#11 15.31 ERROR: Cannot install -r requirements.txt (line 9) and protobuf==3.18.1 because these package versions have conflicting dependencies.
#11 15.31
#11 15.31 The conflict is caused by:
#11 15.31     The user requested protobuf==3.18.1
#11 15.31     google-api-core 1.31.3 depends on protobuf<3.18.0 and >=3.12.0
#11 15.31
#11 15.31 To fix this you could try to:
#11 15.31 1. loosen the range of package versions you've specified
#11 15.31 2. remove package versions to allow pip attempt to solve the dependency conflict
```
# Issue number <!-- e.g. Close #123, Fix #456 -->

Close #

# How to check the revision

# Points for Review <!-- Things you want reviewers to check, etc. -->

# Remarks <!-- Any other comments -->

<!-- You don't have to fill in all the blanks, but write the necessary information clearly. -->